### PR TITLE
fix: build error

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,9 +32,9 @@
 
 namespace autoware::trajectory_interpolator::utils
 {
-using autoware::trajectory::interpolator::AkimaSpline;
+using autoware::experimental::trajectory::interpolator::AkimaSpline;
 using InterpolationTrajectory =
-  autoware::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
+  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
 
 rclcpp::Logger get_logger()
 {


### PR DESCRIPTION
## Description
The namespace was changed in https://github.com/autowarefoundation/autoware_core/pull/371, so applied this change.

## How it was tested
Was able to build.